### PR TITLE
Fix issue with episode input bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,12 +13,13 @@ function App() {
 
   const handleOnChange = (event) => {
     const newValue = parseInt(event.target.value);
-    if (newValue > 0) {
+    if (!isNaN(newValue)) {
       setValue(newValue);
     } else {
-      setValue(1);
+      setValue('');
     }
   };
+  
   
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {


### PR DESCRIPTION
Closes #2 

Description
fixed the episode input bar to allow users to delete the initial digit '1' when entering episode numbers between 11 to 19. This change improves usability by enabling users to input episode numbers more flexibly.

Changes Made:

Updated the handleOnChange function in App.jsx to specifically allow deletion of the initial digit '1' in the episode input bar.
Modified the conditional statement within handleOnChange to check for the specific scenario where the user is attempting to delete the initial '1' digit and adjust the input accordingly.

https://github.com/Avdhesh-Varshney/Chanakya-Niti/assets/146753809/a4b33d91-dbb9-4a1d-8170-07c8a00beff5


