### PR TITLE
Fix last track playing after searching an invalid episode (#44)

### DIFF
--- a/src/components/Pages/RequestEpisode.jsx
+++ b/src/components/Pages/RequestEpisode.jsx
@@ -51,6 +51,8 @@ const RequestEpisode = (props) => {
       } catch (error) {
         console.error('Error fetching episode:', error);
         setContent('Error fetching episode');
+        // audio player should also be stopped in case of invalid episodes
+        setUrl('');
       }
       setProgress(100);
     };


### PR DESCRIPTION
Hi maintainers,

This pull request addresses the issue reported in [#44 ] regarding the track playing after searching an invalid episode.

Changes Introduced:
Added a line of code to reset the episode URL to its default value. This ensures the episode URL is properly reset after each use.

Thanks
Madhav Dua
(SSOC contributor)