### PR TITLE
fix test not visible in dark mode of dropdown resources

### DIFF
--- a/src/css/Home.css
+++ b/src/css/Home.css
@@ -353,3 +353,6 @@ justify-content: center;
 align-items: center;
 font-size: 1.5rem;
 }
+.dark .dropdown-menu.show{
+  background-color: #353535;
+}


### PR DESCRIPTION
Closes: #220 
- **Title** : Text not visible in dark mode 
- **Name:** Maana Ajmera
-  **Idenitfy yourself:** GSSOC


<!-- Mention the following details and these are mandatory -->

### Describe the add-ons or changes you've made 📃

- Earlier text was not visible for resource section dropdown in dark mode.
- I have adjusted the background according to dark theme , and now text in dropdown is visible in both night mode and dark mode

Give a clear description of what have you added or modifications made


### Type of change ☑️
<!-- Please delete options that are not relevant. -->
What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code style update (formatting, local variables)


### Checklist: ☑️
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] My code follows the [Contributing Guidelines](https://github.com/Avdhesh-Varshney/Chanakya-Niti/blob/main/README.md) & [Code of Conduct](https://github.com/Avdhesh-Varshney/Chanakya-Niti/blob/main/CODE_OF_CONDUCT.md) of this project.
- [X] This PR does not contain plagiarized content.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly wherever it was hard to understand.
- [X] My changes generate no new warnings.


### Screenshots 📷
Before :

https://github.com/Avdhesh-Varshney/chanakya-niti/assets/162733812/020f947f-1c67-4511-92d9-fbbd181bd4d6

After :


https://github.com/Avdhesh-Varshney/chanakya-niti/assets/162733812/822276b6-788c-4156-b011-dfc2769a017b



