### PR TITLE
used Recoil for toggletheme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "react-router-dom": "^6.27.0",
         "react-spinners": "^0.14.1",
         "react-top-loading-bar": "^2.3.1",
-        "react-typed": "^2.0.12"
+        "react-typed": "^2.0.12",
+        "recoil": "^0.7.7"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",
@@ -3331,6 +3332,11 @@
         "web-streams-polyfill": "^3.2.1"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -4597,6 +4603,25 @@
       },
       "peerDependencies": {
         "react": ">16.8.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-router-dom": "^6.27.0",
     "react-spinners": "^0.14.1",
     "react-top-loading-bar": "^2.3.1",
-    "react-typed": "^2.0.12"
+    "react-typed": "^2.0.12",
+    "recoil": "^0.7.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,9 +27,14 @@ import "./App.css";
 import AnimatedCursor from "react-animated-cursor";
 
 import { FaAngleDoubleUp } from "react-icons/fa";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { themeState } from "./atoms/ThemeAtom";
+import { toggleThemeSelector } from "./atoms/ThemeAtom";
 
 function App() {
-  const { progress, isDarkMode } = useContext(Context); // Assuming isDarkMode is provided in your context
+  const { progress} = useContext(Context);
+  const isDarkMode = useRecoilValue(themeState); //to use the current theme 
+  const toggleTheme = useSetRecoilState(toggleThemeSelector); //to update the state  
 
   const [showScroll, setShowScroll] = useState(false);
 
@@ -65,6 +70,11 @@ function App() {
   useEffect(() => {
     document.body.classList.toggle("dark", isDarkMode);
   }, [isDarkMode]);
+
+  // useEffect(() => {
+  //   // Add or remove the "dark" class on the body based on isDarkMode
+  //   document.body.classList.toggle("dark", isDarkMode);
+  // }, [isDarkMode]);
 
   return (
     <div className={`d-flex flex-column ${isDarkMode ? "dark" : ""}`}>

--- a/src/atoms/ThemeAtom
+++ b/src/atoms/ThemeAtom
@@ -1,0 +1,28 @@
+import { atom, selector } from 'recoil';
+
+const getInitialDarkMode = () => {
+  const savedMode = localStorage.getItem('darkMode');
+  return savedMode === 'true'; // Convert saved string back to boolean
+};
+
+export const themeState = atom({
+  key: 'themeState',
+  default: getInitialDarkMode(), // Use the initial value from localStorage
+  effects_UNSTABLE: [
+    ({ onSet }) => {
+      onSet((newMode) => {
+        localStorage.setItem('darkMode', newMode.toString()); // Store as string
+      });
+    },
+  ],
+});
+
+// Selector to toggle theme
+export const toggleThemeSelector = selector({
+  key: 'toggleThemeSelector',
+  get: ({ get }) => get(themeState),
+  set: ({ get, set }) => {
+    const currentMode = get(themeState);
+    set(themeState, !currentMode); // Toggle the theme
+  },
+});

--- a/src/components/shared/Footer.jsx
+++ b/src/components/shared/Footer.jsx
@@ -19,9 +19,11 @@ import Tilt from "react-parallax-tilt";
 import "../../css/Footer.css";
 import { TbHelpSquareFilled } from "react-icons/tb";
 import GoogleTranslate from "../../pages/contributor/GoogleTranslate";
+import { themeState } from "../../atoms/ThemeAtom";
+import { useRecoilValue } from "recoil";
 
 const Footer = () => {
-  const { isDarkMode } = useContext(Context);
+  const isDarkMode = useRecoilValue(themeState); //to use the current theme 
 
   return (
     <footer

--- a/src/components/shared/Navbar.jsx
+++ b/src/components/shared/Navbar.jsx
@@ -3,9 +3,13 @@ import { Link } from "react-router-dom";
 import { MdOutlineDarkMode, MdOutlineLightMode } from "react-icons/md";
 import { Context } from "../../context/Context";
 import '../shared/Navbar.css';
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { themeState } from "../../atoms/ThemeAtom";
+import { toggleThemeSelector } from "../../atoms/ThemeAtom";
 
 const Navbar = () => {
-  const { isDarkMode, toggleTheme } = useContext(Context);
+  const isDarkMode = useRecoilValue(themeState); //to use the current theme 
+  const toggleTheme = useSetRecoilState(toggleThemeSelector); //to update the state  
   const [isSticky, setIsSticky] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(true);
 

--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -3,27 +3,11 @@ import React, { createContext, useState, useEffect } from 'react';
 export const Context = createContext();
 
 const ContextProvider = ({ children }) => {
-  const getInitialDarkMode = () => localStorage.getItem('darkMode') === 'true';
-
   const [progress, setProgress] = useState(0);
-  const [isDarkMode, setDarkMode] = useState(getInitialDarkMode);
-
-  useEffect(() => {
-    localStorage.setItem('darkMode', isDarkMode);
-  }, [isDarkMode]);
-
-  const toggleTheme = () => {
-    setDarkMode((prevMode) => {
-      const newMode = !prevMode;
-      localStorage.setItem('darkMode', newMode ? 'dark' : 'light');
-      return newMode;
-    });
-  };
 
   return (
     <Context.Provider value={{
       progress, setProgress,
-      isDarkMode, toggleTheme,
     }}>
       {children}
     </Context.Provider>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,11 +5,14 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import 'bootstrap/dist/js/bootstrap.bundle.min';
 import "./index.css"
 import ContextProvider from "./context/Context";
+import { RecoilRoot } from "recoil";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <ContextProvider>
-      <App />
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
     </ContextProvider>
   </React.StrictMode>,
 );

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,9 +1,11 @@
 import React, { useContext } from 'react';
 import { BiCalendar, BiMap, BiUser, BiBook, BiBriefcase, BiWorld, BiCalendarX } from 'react-icons/bi';
 import { Context } from '../context/Context'; // Assuming your context file is located here
+import { themeState } from '../atoms/ThemeAtom';
+import { useRecoilValue } from 'recoil';
 
 const About = () => {
-  const { isDarkMode } = useContext(Context);
+  const isDarkMode = useRecoilValue(themeState); //to use the current theme 
 
   return (
     <div className={`container p-4 ${isDarkMode ? 'text-white' : 'text-dark'}`} style={{ backgroundColor: isDarkMode ? '#333' : 'rgba(228, 193, 129, 0.272);' }}>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,9 +3,11 @@ import { ReactTyped } from "react-typed";
 import VideoButton from "../components/Home/VideoButton";
 import Tilt from 'react-parallax-tilt';
 import { Context } from '../context/Context';
+import { themeState } from "../atoms/ThemeAtom";
+import { useRecoilValue } from "recoil";
 
 export default function Home() {
-  const { isDarkMode } = useContext(Context);
+  const isDarkMode = useRecoilValue(themeState); //to use the current theme 
 
   return (
     <div className={`d-flex flex-column align-items-center ${isDarkMode ? 'dark-mode' : 'light-mode'}`} style={{ color: isDarkMode ? 'white' : 'black' }}>


### PR DESCRIPTION
Closes: <!-- #issue number  -->

- **Title** : Optimization in code structure
- **Name:** AADESHak007
- **Idenitfy yourself:** GSSOC-extd Contributor 2024


<!-- Mention the following details and these are mandatory -->

### Describe the add-ons or changes you've made 📃
#### This Fixes #358 

Earlier the context API was used to toggle theme . I have used RECOIL js to to change the theme of the website .
This will enhance the loading speed of the website and will reduce the number of re rendering .
Will make this a more robust Client side rendering App .

###### I did not touched the `ProgressBar` code  because of the following reasons :
* it is not being used at many places .
* using Recoil for it wouldn't make that big of a difference 
`conclusion:` it was not the case where you would use RECOIL .


### Type of change ☑️
<!-- Please delete options that are not relevant. -->
What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)



### Checklist: ☑️
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the [Contributing Guidelines](https://github.com/Avdhesh-Varshney/Chanakya-Niti/blob/main/README.md) & [Code of Conduct](https://github.com/Avdhesh-Varshney/Chanakya-Niti/blob/main/CODE_OF_CONDUCT.md) of this project.
- [x] This PR does not contain plagiarized content.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.


### Screenshots 📷
<!-- Must add the screenshot of the project or your changes for review your pr -->

https://github.com/user-attachments/assets/515c8b27-81a6-4d0f-9a07-abae8674f090





### Note to reviewers 📄
<!-- Add notes to reviewers if applicable -->

